### PR TITLE
Replace depreacted buffer get set

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,11 +358,11 @@ BitWriter.prototype._makeArrayLike = function makeArrayLike() {
   for (var n = 0; n < this.length; n++) {
     (function (n) {
       Object.defineProperty(this, n, {
-        get: function () { return this[n] },
+        get: function () { return this._buffer[n] },
         set: function (v) {
           if (!eightBitRange.test(v))
             throw errors.range(v, eightBitRange);
-          return this[n] = v;
+          return this._buffer[n] = v;
         },
         enumerable: true,
         configurable: true


### PR DESCRIPTION
Buffer.prototype.get and Buffer.prototype.set are going to be removed in v0.13 ([see here](https://github.com/joyent/node/blob/master/lib/buffer.js#L300). I think they are also causing they might also cause troubles with browserify.
